### PR TITLE
linedb: send `%fact`s `+sss-on-rock`

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -73,7 +73,18 @@
           ~&  >>>  "not allowed to surf on {<msg>}"
           `state
         ::
-            %sss-on-rock  `state  :: a rock has updated
+            %sss-on-rock  :: a rock has updated
+          =+  !<([p=path src=@p @ ? ? *] vase)
+          ?>  ?=([@ @ ~] p)  ::  TODO: is this true?
+          =*  repo-path=path
+            /repo-updates/(scot %p src)/[i.p]
+          =*  branch-path=path  [(scot %p src) p]
+          :_  state
+          :_  ~
+          :^  %give  %fact
+            ~[repo-path [%branch-updates branch-path]]
+          :-  %linedb-update
+          !>(`update`[%new-data branch-path])
         ==
       [cards this]
     ::
@@ -89,15 +100,31 @@
           [~ %sss %scry-request @ @ @ @tas @tas ~]  (tell:dab |3:wire sign)
         ==
       [cards this]
-    ++  on-watch  on-watch:def
+    ::
+    ++  on-watch
+      |=  =path
+      ^-  (quip card _this)
+      ?+  path  (on-watch:def path)
+        [%repo-updates @ @ ~]      `this  ::  host repo
+        [%branch-updates @ @ @ ~]  `this  ::  host repo branch
+      ==
+    ::
+    ++  on-leave
+      |=  =path
+      ^-  (quip card _this)
+      ?+  path  (on-leave:def path)
+        [%repo-updates @ @ ~]      `this  ::  host repo
+        [%branch-updates @ @ @ ~]  `this  ::  host repo branch
+      ==
+    ::
     ++  on-peek   handle-peek:hc
+    ::
     ++  on-arvo
       |=  [=wire sign=sign-arvo]
       ^-  (quip card:agent:gall _this)
       ?+  wire  `this
         [~ %sss %behn @ @ @ @tas @tas ~]  [(behn:dab |3:wire) this]
       ==
-    ++  on-leave  on-leave:def
     ++  on-fail   on-fail:def
     --
 ::

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -65,5 +65,6 @@
   ==
 +$  update
   $%  [%build result=(each vase @t)]
+      [%new-data =path]
 ==
 --


### PR DESCRIPTION
*Problem*

%ziggurat needs to have a way to know when repos/branches of interest are updated.

*Solution*

Allow subscription (old subscription); when `+sss-on-rock` fires, send the path of the repo to subscribers.

*Notes*

1. %ziggurat needs to know when repos/branches are updated so it can sync files to %pyro.
2. Subscriptions will always be on same ship (since they are concerned with state of our own %linedb); as such, using old subscriptions seemed reasonable, especially considering the amount of SSS boilerplate.
3. Updates work fine for remote repos that our %linedb has `%fetch`d. To get updates to work for local repos, we much `%fetch` our own repo. This is pretty gross.
4. We send the path of the repo rather than the contents of the `rock` because the app in question may not want all that data. E.g., %ziggurat wants to pipe the updated files into %pyro, but the way to do that is using %linedb, so there is no reason to send the `rock`.

I'm open to other solutions. As I say, this is very hacky for local repos. I don't want to put SSS into %ziggurat right now, so this is the hack I landed on.