### PR TITLE
scries added

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -99,9 +99,43 @@
         =*  sss  t.t.t.path
         log:(ba:hc who sss)
       ::
-          [%x %history @ @tas @tas ~]                      ::  list of all hashes
-        =*  who  (slav %p i.t.t.path)
-        =*  sss  t.t.t.path
+          [%x ~]                                           ::  list all repos
+        =/  locals=(list [ship sss-paths])
+          %+  turn  ~(tap by read:dub)
+          |=  [=sss-paths *]
+          [our.bowl sss-paths]
+        =/  remotes=(list [ship sss-paths])
+          %+  turn  ~(tap by read:dab)
+          |=  [[=ship * =sss-paths] *]
+          [ship sss-paths]
+        (weld locals remotes)
+      ::
+          [%x @ ~]                                         ::  repos of ship
+        =/  who  (slav %p i.t.path)
+        ?:  =(who our.bowl)
+          %+  turn  ~(tap by read:dub)
+          |=([=sss-paths *] sss-paths)
+        %+  murn  ~(tap by read:dab)
+        |=  [[=ship * =sss-paths] *]
+        ?:(=(ship who) `sss-paths ~)
+      ::
+          [%x @ @tas ~]                                    ::  branches of repo
+        :: TODO this is not easy the way we have it set up with +ba
+        ::   makes me think maybe we should do a refactor to make
+        ::   repos "real"?
+        =/  who  (slav %p i.t.path)
+        =*  repo  i.t.t.path
+        ?:  =(who our.bowl)
+          %+  murn  ~(tap by read:dub)
+          |=  [p=sss-paths *]
+          ?:(=(-.p repo) `p ~)
+        %+  murn  ~(tap by read:dab)
+        |=  [[=ship * p=sss-paths] *]
+        ?:(&(=(ship who) =(-.p repo)) `p ~)
+      ::
+          [%x @ @tas @tas ~]                               ::  log of branch
+        =*  who  (slav %p i.t.path)
+        =*  sss  t.t.path
         history:(ba:hc who sss)
       ::
           [%x @ @tas @tas ?(%head @) ~]                    ::  get a list of files

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -3,6 +3,28 @@
 =,  format
 =,  differ
 |%
+:: ++  park
+::   |=  [repo=@tas vases=(list [dude:gall vase])]
+::   :^  %pass  /  %arvo
+::   :-  %c
+::   :^  %park  repo
+::     ^-  yoki:clay
+::     :+  %&  ~
+::     %-  ~(gas by *(map path (each page lobe:clay)))
+::     ^-  (list [path %& page])
+::     %+  weld  boilerplate-files:ldb
+::     %+  weld  [/desk/bill %& %bill bill.act]~
+::     %+  weld  all-files
+::     ^-  (list [path %& page])
+::     %-  zing
+::     %+  turn  vases
+::     |=  [=dude:gall vaz=(each vase @t)]
+::     ?>  =(%& -.vaz)
+::     :~  [/app/[dude]/vase %& %vase p.vaz]
+::         [/app/[dude]/hoon %& %hoon (gen-app:ldb /app/[dude]/vase)]
+::     ==
+::   .^(rang:clay %cx /(scot %p our.bowl)//(scot %da now.bowl)/rang)
+::
 ++  noun-mark
     '''
     /?    310


### PR DESCRIPTION
Implements the "smart scries" idea where every part of the main path is defined (see #8 )
- `/=linedb=/` gives you all repos from all local and remote repos
- `/=linedb=/~nec/` gives you all repos from ~nec
- `/=linedb=/~nec/my-repo/` gives you all branches from `my-repo`
- `/=linedb=/~nec/my-repo/my-branch/` gives you all commit hashes for `my-branch`
- `/=linedb=/~nec/my-repo/my-branch/0x.../` gives you all files in that commit hash
- `/=linedb=/~nec/my-repo/my-branch/0x.../some/file/path/`gives you the text of the file at that commit hash