### PR TITLE
diff scry done

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -121,15 +121,15 @@
       =-  ``noun+!>(-)
       ?+    path  (on-peek:def path)
       ::
-          [%x ~]  ~(tap by ~(key by all-rocks:hc))         ::  list all repos
+          [%x ~]  ~(tap by ~(key by all-rocks:hc))     ::  list all repos
       ::
-          [%x @ ~]                                         ::  repos of ship
+          [%x @ ~]                                     ::  repos of ship
         =/  who  (slav %p i.t.path)
         %+  murn  ~(tap by all-rocks:hc)
         |=  [[=ship =sss-paths] *]
         ?:(=(ship who) `sss-paths ~)
       ::
-          [%x @ @tas ~]                                    ::  branches of repo
+          [%x @ @tas ~]                                ::  branches of repo
         :: TODO this is not easy the way we have it set up with +ba
         ::   makes me think maybe we should do a refactor to make
         ::   repos "real"?
@@ -139,12 +139,12 @@
         |=  [[=ship =sss-paths] *]
         ?:(&(=(ship who) =(-.sss-paths repo)) `sss-paths ~)
       ::
-          [%x @ @tas @tas ~]                               ::  log of branch
+          [%x @ @tas @tas ~]                           ::  log of branch
         =*  who  (slav %p i.t.path)
         =*  sss  t.t.path
         log:(~(gut by all-rocks:hc) [who sss] *branch)
       ::
-          [%x @ @tas @tas ?(%head @) ~]                    ::  get a list of files
+          [%x @ @tas @tas ?(%head @) ~]                ::  get a list of files
         =*  who          (slav %p i.t.path)
         =*  repo                i.t.t.path
         =*  branch            i.t.t.t.path
@@ -154,7 +154,16 @@
           @      ~(tap by (get-snap:(ba-core:hc who [repo branch ~]) (slav %ux hash)))
         ==
       ::
-          [%x @ @tas @tas ?(%head @) ^]                    ::  read a file
+          [%x @ @tas @tas %diff @ @ ^]                 ::  diff two files
+        =*  who         `@p`(slav %p i.t.path)
+        =*  repo                   i.t.t.path
+        =*  branch               i.t.t.t.path
+        =*  haz    (slav %ux i.t.t.t.t.t.path)
+        =*  hax  (slav %ux i.t.t.t.t.t.t.path)
+        =*  fil            t.t.t.t.t.t.t.path
+        (get-diff:(ba-core:hc who repo branch ~) haz hax fil)
+      ::
+          [%x @ @tas @tas ?(%head @) ^]                ::  read a file
         =*  who  (slav %p i.t.path)
         =*  repo        i.t.t.path
         =*  branch    i.t.t.t.path

--- a/lib/branch.hoon
+++ b/lib/branch.hoon
@@ -87,6 +87,12 @@
   |=  [hstk=path =file]
   ?.  =(`0 (find nedl hstk))  ~
   `[hstk file]
+++  get-diff
+  |=  [haz=hash hax=hash fil=path]
+  ^-  diff
+  %+  diff-files:di:ldb
+    (~(gut by (get-snap haz)) fil *wain)
+  (~(gut by (get-snap hax)) fil *wain)
 ::
 ++  hashes  (turn log.branch |=(=ceta hash.ceta))
 --


### PR DESCRIPTION
Resolves #9 
Adds a scry for a diff `(urge:clay cord)`
Requires more information to construct the git-style diff (the file/wain) but works for now