### PR TITLE
linedb: send diffs, rather than snap, on commit

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -264,7 +264,14 @@
     =/  head-snap=snap
       snap:(~(gut by commits.branch) head-hash *commit)
     ?:  =(head-snap snap.act)  `state
-    =*  dif  (diff-snaps:di:ldb head-snap snap.act)
+    =*  dif
+      %-  ~(gas by *(map path diff))
+      %+  murn
+        ~(tap by (diff-snaps:di:ldb head-snap snap.act))
+      |=  [p=path d=diff]
+      ::  file without diff has one entry that looks like
+      ::   [%.y @ud], with @ud the final line of the wain
+      ?:  =(1 (lent d))  ~  `[p d]
     =^  cards  pubs
       (give:dub [repo branch ~]:act %commit our.bowl now.bowl dif)
     [cards state]

--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -240,6 +240,12 @@
   |=  [[=ship * =sss-paths] * * =rock:bur]
   [[ship sss-paths] rock]
 ::
+++  a-rock
+  |=  =sss-paths
+  ^-  (unit rock:bur)
+  ?~  result=(~(get by read:dub) sss-paths)  ~
+  `rock.u.result
+::
 ::  see +branch
 ::
 ++  ba-core
@@ -252,8 +258,15 @@
   ^-  (quip card _state)
   ?-    -.act
       %commit
+    =/  =branch
+      (fall (a-rock /[repo.act]/[branch.act]) *branch)
+    =/  head-hash=@ux  ?~(log.branch 0x0 hash.i.log.branch)
+    =/  head-snap=snap
+      snap:(~(gut by commits.branch) head-hash *commit)
+    ?:  =(head-snap snap.act)  `state
+    =*  dif  (diff-snaps:di:ldb head-snap snap.act)
     =^  cards  pubs
-      (give:dub [repo branch ~]:act %commit our.bowl now.bowl snap.act)
+      (give:dub [repo branch ~]:act %commit our.bowl now.bowl dif)
     [cards state]
   ::
       %merge

--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -154,7 +154,7 @@
         =*  who  (slav %p i.t.path)
         =*  sss  t.t.path
         :^  ~  ~  %linedb-log
-        !>  ^-  (list ceta)
+        !>  ^-  (list meta)
         log:(~(gut by all-rocks:hc) [who sss] *branch)
       ::
           [%x @ @tas @tas ?(%head @) ~]

--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -226,6 +226,7 @@
          (da subs bowl -:!>(*result:da) -:!>(*from:da) -:!>(*fail:da))
     dub  =/  du  (du:sss bur sss-paths)
          (du pubs bowl -:!>(*result:du))
+::
 ++  all-rocks
   ^-  (map [ship sss-paths] rock:bur)
   %-  %~  uni  by
@@ -240,11 +241,11 @@
   |=  [[=ship * =sss-paths] * * =rock:bur]
   [[ship sss-paths] rock]
 ::
-++  a-rock
-  |=  =sss-paths
-  ^-  (unit rock:bur)
-  ?~  result=(~(get by read:dub) sss-paths)  ~
-  `rock.u.result
+++  pub-rocks
+  ^-  (map sss-paths rock:bur)
+  %-  ~(gas by *(map sss-paths rock:bur))
+  %+  turn  ~(tap by read:dub)
+  |=([=sss-paths * =rock:bur] [sss-paths rock])
 ::
 ::  see +branch
 ::
@@ -258,26 +259,15 @@
   ^-  (quip card _state)
   ?-    -.act
       %commit
-    =/  =branch
-      (fall (a-rock /[repo.act]/[branch.act]) *branch)
-    ?~  log.branch
-      =^  cards  pubs
-        (give:dub [repo branch ~]:act %first-commit our.bowl now.bowl snap.act)
-      [cards state]
-    =*  head-hash=@ux  hash.i.log.branch
-    =/  head-snap=snap
-      snap:(~(gut by commits.branch) head-hash *commit)
-    ?:  =(head-snap snap.act)  `state
-    =*  dif
-      %-  ~(gas by *(map path diff))
-      %+  murn
-        ~(tap by (diff-snaps:di:ldb head-snap snap.act))
-      |=  [p=path d=diff]
-      ::  file without diff has one entry that looks like
-      ::   [%.y @ud], with @ud the final line of the wain
-      ?:  =(1 (lent d))  ~  `[p d]
+    =/  hed
+      =<  head-snap
+      =;  ban  bil(branch ban)
+      (~(gut by pub-rocks) [repo branch ~]:act *branch)
+    ?:  =(hed snap.act)  `state
     =^  cards  pubs
-      (give:dub [repo branch ~]:act %commit our.bowl now.bowl dif)
+      %+  give:dub  [repo branch ~]:act
+      :^  %commit  our.bowl  now.bowl
+      (diff-snaps:di:ldb hed snap.act)
     [cards state]
   ::
       %merge

--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -260,7 +260,11 @@
       %commit
     =/  =branch
       (fall (a-rock /[repo.act]/[branch.act]) *branch)
-    =/  head-hash=@ux  ?~(log.branch 0x0 hash.i.log.branch)
+    ?~  log.branch
+      =^  cards  pubs
+        (give:dub [repo branch ~]:act %first-commit our.bowl now.bowl snap.act)
+      [cards state]
+    =*  head-hash=@ux  hash.i.log.branch
     =/  head-snap=snap
       snap:(~(gut by commits.branch) head-hash *commit)
     ?:  =(head-snap snap.act)  `state

--- a/lib/branch.hoon
+++ b/lib/branch.hoon
@@ -7,31 +7,19 @@
 ::
 ::  write arms
 ::
-++  add-commit-via-diff
+++  add-commit
   |=  [author=ship time=@da diffs=(map path diff)]
   ^+  branch
-  =/  new-ceta=ceta
+  =/  =ceta
     [`@ux`(sham [snap head author time]) head author time]
-  =/  [old-ceta=ceta old-snap=snap]
-    ?~  log.branch  [*ceta *snap]
-    (~(gut by commits.branch) hash.i.log.branch [*ceta *snap])
-  ?.  =(hash.old-ceta parent.new-ceta)
-    ::  TODO: how to do better than just rejecting commit?
-    branch
   %=    branch
-      log  [new-ceta log.branch]
+      log  [ceta log.branch]
       commits
-    %+  ~(put by commits.branch)  hash.new-ceta
-    [new-ceta (apply-diffs:di:ldb old-snap diffs)]
-  ==
-::
-++  add-commit
-  |=  [author=ship time=@da =snap]
-  ^+  branch
-  =/  =ceta  [`@ux`(sham snap) head author time]
-  %=  branch
-    log      [ceta log.branch]
-    commits  (~(put by commits.branch) hash.ceta [ceta snap])
+    %+  ~(put by commits.branch)  hash.ceta
+    :-  ceta
+    %+  apply-diffs:di:ldb
+      snap:(~(gut by commits.branch) parent.ceta *commit)
+    diffs
   ==
 ::
 ++  squash
@@ -40,7 +28,8 @@
   =/  hed=commit  head-commit
   =.  branch  (reset:ba-core hash)
   =.  parent.ceta.hed  ~(head ba-core branch)
-  (add-commit:ba-core [author.ceta time.ceta snap]:hed)
+  %^  add-commit:ba-core  author.ceta.hed  time.ceta.hed
+  (diff-snaps:di:ldb head-snap snap:hed)
 ::
 ++  merge
   |=  [author=@p time=@da bab=^branch]
@@ -69,13 +58,7 @@
     %+  three-way-merge:di:ldb
       [%current (~(gut by ali-diffs) path *diff)]
     [%incoming (~(gut by bob-diffs) path *diff)]
-  =/  new-snap=snap
-    ?~  log.branch  *snap
-    %-  ~(urn by snap:(~(got by commits.branch) head:ali))
-    |=  [=path =file]
-    =+  dif=(~(got by diffs) path)
-    (apply-diff:di:ldb file dif)
-  (add-commit:ba-core author time new-snap)
+  (add-commit:ba-core author time diffs)
 ::
 ++  reset
   |=  =hash

--- a/lib/branch.hoon
+++ b/lib/branch.hoon
@@ -10,14 +10,14 @@
 ++  add-commit
   |=  [author=ship time=@da diffs=(map path diff)]
   ^+  branch
-  =/  =ceta  [`@ux`(sham snap) head author time]
+  =/  =meta  [`@ux`(sham head author time snap) head author time]
   %=    branch
-      log  [ceta log.branch]
+      log  [meta log.branch]
       commits
-    %+  ~(put by commits.branch)  hash.ceta
-    :-  ceta
+    %+  ~(put by commits.branch)  hash.meta
+    :-  meta
     %+  apply-diffs:di:ldb
-      snap:(~(gut by commits.branch) parent.ceta *commit)
+      snap:(~(gut by commits.branch) parent.meta *commit)
     diffs
   ==
 ::
@@ -26,8 +26,8 @@
   ^+  branch
   =/  hed=commit  head-commit
   =.  branch  (reset:ba-core hash)
-  =.  parent.ceta.hed  ~(head ba-core branch)
-  %^  add-commit:ba-core  author.ceta.hed  time.ceta.hed
+  =.  parent.meta.hed  ~(head ba-core branch)
+  %^  add-commit:ba-core  author.meta.hed  time.meta.hed
   (diff-snaps:di:ldb head-snap snap:hed)
 ::
 ++  merge
@@ -98,5 +98,5 @@
   ^-  (map path diff)
   (diff-snaps:di:ldb (get-snap haz) (get-snap hax))
 ::
-++  hashes  (turn log.branch |=(=ceta hash.ceta))
+++  hashes  (turn log.branch |=(=meta hash.meta))
 --

--- a/lib/branch.hoon
+++ b/lib/branch.hoon
@@ -7,6 +7,24 @@
 ::
 ::  write arms
 ::
+++  add-commit-via-diff
+  |=  [author=ship time=@da diffs=(map path diff)]
+  ^+  branch
+  =/  new-ceta=ceta
+    [`@ux`(sham [snap head author time]) head author time]
+  =/  [old-ceta=ceta old-snap=snap]
+    ?~  log.branch  [*ceta *snap]
+    (~(gut by commits.branch) hash.i.log.branch [*ceta *snap])
+  ?.  =(hash.old-ceta parent.new-ceta)
+    ::  TODO: how to do better than just rejecting commit?
+    branch
+  %=    branch
+      log  [new-ceta log.branch]
+      commits
+    %+  ~(put by commits.branch)  hash.new-ceta
+    [new-ceta (apply-diffs:di:ldb old-snap diffs)]
+  ==
+::
 ++  add-commit
   |=  [author=ship time=@da =snap]
   ^+  branch

--- a/lib/branch.hoon
+++ b/lib/branch.hoon
@@ -10,8 +10,7 @@
 ++  add-commit
   |=  [author=ship time=@da diffs=(map path diff)]
   ^+  branch
-  =/  =ceta
-    [`@ux`(sham [snap head author time]) head author time]
+  =/  =ceta  [`@ux`(sham snap) head author time]
   %=    branch
       log  [ceta log.branch]
       commits

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -78,7 +78,11 @@
     |=  [=path *]
     =;  =diff
       ::  NOTE: if no changes, don't send the diff
-      ?:(=(1 (lent diff)) ~ `[path diff])
+      ?:  ?&  =(1 (lent diff))
+              ?=(^ diff)
+              =([%& 5] diff)
+          ==
+      ~  `[path diff]
     %+  diff-files
       (~(gut by old) path *file)
     (~(gut by new) path *file)

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -26,6 +26,15 @@
   |%
   ++  diff-files  |=([old=file new=file] (lusk old new (loss old new)))
   ++  apply-diff  |=([=file =diff] (lurk file diff))
+  ++  apply-diffs
+    |=  [old-snap=snap diffs=(map path diff)]
+    ^-  snap
+    %-  ~(gas by old-snap)
+    %+  turn  ~(tap by diffs)
+    |=  [p=path d=diff]
+    :-  p
+    %-  apply-diff  :_  d
+    (~(gut by old-snap) p *wain)
   ::
   ++  line-mapping
     |=  =diff

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -27,14 +27,15 @@
   ++  diff-files  |=([old=file new=file] (lusk old new (loss old new)))
   ++  apply-diff  |=([=file =diff] (lurk file diff))
   ++  apply-diffs
-    |=  [old-snap=snap diffs=(map path diff)]
-    ^-  snap
-    %-  ~(gas by old-snap)
+    |=  [=snap diffs=(map path diff)]
+    ^-  ^snap
+    %-  ~(gas by snap)
     %+  turn  ~(tap by diffs)
-    |=  [p=path d=diff]
-    :-  p
-    %-  apply-diff  :_  d
-    (~(gut by old-snap) p *wain)
+    |=  [=path =diff]
+    :-  path
+    %+  apply-diff
+      (~(gut by snap) path *wain)
+    diff
   ::
   ++  line-mapping
     |=  =diff

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -80,7 +80,7 @@
       ::  NOTE: if no changes, don't send the diff
       ?:  ?&  =(1 (lent diff))
               ?=(^ diff)
-              =([%& 5] diff)
+              =(%& -.i.diff)
           ==
       ~  `[path diff]
     %+  diff-files

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -73,8 +73,12 @@
   ++  diff-snaps                                       ::  from two snaps
     |=  [old=snap new=snap]
     ^-  (map path diff)
-    %-  ~(urn by (~(uni by old) new))
+    %-  ~(gas by *(map path diff))
+    %+  murn  ~(tap by (~(uni by old) new))
     |=  [=path *]
+    =;  =diff
+      ::  NOTE: if no changes, don't send the diff
+      ?:(=(1 (lent diff)) ~ `[path diff])
     %+  diff-files
       (~(gut by old) path *file)
     (~(gut by new) path *file)
@@ -269,7 +273,7 @@
     ~
   ::
   ++  log
-    |=  log=(list ceta)
+    |=  log=(list meta)
     ^-  json
     :-  %a
     %+  turn  log

--- a/mar/linedb/log.hoon
+++ b/mar/linedb/log.hoon
@@ -1,10 +1,10 @@
 /-  ldb=linedb
 /+  linedb
 ::
-|_  log=(list ceta:ldb)
+|_  log=(list meta:ldb)
 ++  grab
   |%
-  ++  noun  (list ceta:ldb)
+  ++  noun  (list meta:ldb)
   --
 ::
 ++  grow

--- a/sur/branch.hoon
+++ b/sur/branch.hoon
@@ -4,7 +4,7 @@
 ++  name  %branch
 +$  rock  branch
 +$  wave
-  $%  [%commit our=ship now=@da =snap]
+  $%  [%commit our=ship now=@da diffs=(map path diff)]
       [%merge our=ship now=@da =branch]
       [%squash =hash]
       [%reset =hash]
@@ -14,7 +14,7 @@
   |=  [=rock =wave]
   ^+  rock
   ?-  -.wave
-    %commit  (~(add-commit bil rock) [our now snap]:wave)
+    %commit  (~(add-commit-via-diff bil rock) [our now diffs]:wave)
     %merge   (~(merge bil rock) [our now branch]:wave)
     %squash  (~(squash bil rock) hash.wave)
     %reset   (~(reset bil rock) hash.wave)

--- a/sur/branch.hoon
+++ b/sur/branch.hoon
@@ -4,8 +4,7 @@
 ++  name  %branch
 +$  rock  branch
 +$  wave
-  $%  [%first-commit our=ship now=@da =snap]
-      [%commit our=ship now=@da diffs=(map path diff)]
+  $%  [%commit our=ship now=@da diffs=(map path diff)]
       [%merge our=ship now=@da =branch]
       [%squash =hash]
       [%reset =hash]
@@ -15,8 +14,7 @@
   |=  [=rock =wave]
   ^+  rock
   ?-  -.wave
-    %first-commit  (~(add-commit bil rock) [our now snap]:wave)
-    %commit  (~(add-commit-via-diff bil rock) [our now diffs]:wave)
+    %commit  (~(add-commit bil rock) [our now diffs]:wave)
     %merge   (~(merge bil rock) [our now branch]:wave)
     %squash  (~(squash bil rock) hash.wave)
     %reset   (~(reset bil rock) hash.wave)

--- a/sur/branch.hoon
+++ b/sur/branch.hoon
@@ -4,7 +4,8 @@
 ++  name  %branch
 +$  rock  branch
 +$  wave
-  $%  [%commit our=ship now=@da diffs=(map path diff)]
+  $%  [%first-commit our=ship now=@da =snap]
+      [%commit our=ship now=@da diffs=(map path diff)]
       [%merge our=ship now=@da =branch]
       [%squash =hash]
       [%reset =hash]
@@ -14,6 +15,7 @@
   |=  [=rock =wave]
   ^+  rock
   ?-  -.wave
+    %first-commit  (~(add-commit bil rock) [our now snap]:wave)
     %commit  (~(add-commit-via-diff bil rock) [our now diffs]:wave)
     %merge   (~(merge bil rock) [our now branch]:wave)
     %squash  (~(squash bil rock) hash.wave)

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -6,18 +6,18 @@
 +$  file  wain :: ((mop line cord) lth) - doesn't help unless we rewrite clay to be mop based instead of wain based
 +$  diff  (urge:clay cord)
 +$  snap  (map path file) :: maybe use $axal and +of
-+$  ceta
++$  meta
   $:  =hash
       parent=hash
       author=@p
       time=@da
   ==
 +$  commit
-  $:  =ceta
+  $:  =meta
       =snap
   ==
 +$  branch
-  $:  log=(list ceta)
+  $:  log=(list meta)
       commits=(map hash commit)
   ==
 ++  sss-paths  ,[@tas @tas ~] :: /repo/branch


### PR DESCRIPTION
**Problem**

#46. Also: we send `snap` over the wire -- i.e. the entire repo contents -- rather than a diff.

**Solution**

1. Don't commit if given same `snap` as head.
2. Send file diffs over the wire rather than the entire repo contents.

**Notes**

~~TODO: test send times. We hypothesize that the changes here will greatly speed up sending repos for %ziggurat over the wire, but we should confirm with a test to be certain.~~

TODO: how do we upgrade state (i.e. sss state) for a live %linedb on the network?