### PR TITLE
uqbuild: invalidate old cache

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -124,6 +124,11 @@
       %-  mule
       |.
       ?+    path  (on-peek:def path)
+          [%x %cache-size ~]
+        :^  ~  ~  %linedb-cache-size
+        !>  ^-  %+  map  @da
+                [number-cache-entries=@ud total-size=@ud]
+        ~(compute-cache-size-by-day ub ~ cache ~ *@da)
       ::
           [%x ~]                                       ::  list all repos
         :^  ~  ~  %linedb-all-repos

--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -9,7 +9,7 @@
       $:  %0
           subs=_(mk-subs:sss bur sss-paths)
           pubs=_(mk-pubs:sss bur sss-paths)
-          cache=(map @ux vase)
+          cache=build-cache
       ==
     +$  card  $+(card card:agent:gall)
     --
@@ -207,7 +207,7 @@
         :^  ~  ~  %uqbuild-update
         !>  ^-  update
         :-  %build
-        ?^  build=(~(get by cache) file-hash)  [%& u.build]
+        ?^  build=(~(get by p.cache) file-hash)  [%& u.build]
         :-  %|
         ~[leaf+"build not found for file-hash {<file-hash>}"]
       ==
@@ -350,7 +350,7 @@
     =/  [built-file=(each vase tang) =build-state]
       %.  file.act
       %~  build-file  ub
-      :_  [cache ~]
+      :_  [cache ~ (da-to-today:ub now.bowl)]
       ?~  hash.act  head-snap:(ba-core [from repo branch ~]:act)
       (get-snap:(ba-core [from repo branch ~]:act) u.hash.act)
     :_  state(cache cache.build-state)
@@ -389,7 +389,7 @@
     ?~  bill  [res cache]
     =/  [built-file=(each vase tang) =build-state]
       %.  /app/[i.bill]/hoon
-      ~(build-file ub snap cache ~)
+      ~(build-file ub snap cache ~ (da-to-today:ub now.bowl))
     %=  $
       bill   t.bill
       res    [[i.bill built-file] res]

--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -374,6 +374,31 @@
       :+  p.poke-src.act  %linedb-update
       !>(`update`[%build built-file])
     ==
+  ::
+      %clear-cache
+    =/  date-hash-map=(list (pair @da (set @ux)))
+      ~(tap by q.cache)
+    =|  entries-to-delete=(map @ux vase)
+    =^  entries-to-delete=(map @ux vase)  q.cache
+      |-
+      ?~  date-hash-map  [entries-to-delete q.cache]
+      =*  day      p.i.date-hash-map
+      =*  entries  q.i.date-hash-map
+      =*  entries-map
+        %-  ~(gas by *(map @ux vase))
+        (turn ~(tap in entries) |=(h=@ux [h *vase]))
+      %=  $
+          date-hash-map  t.date-hash-map
+      ::
+          entries-to-delete
+        (~(uni by entries-to-delete) entries-map)
+      ::
+          q.cache
+        ?:  (lte before.act day)  q.cache
+        (~(del by q.cache) day)
+      ==
+    =.  p.cache  (~(dif by p.cache) entries-to-delete)
+    `state
   ==
 ::
 ++  build-park

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -305,6 +305,7 @@
         [%merge merge]
         [%branch branch]
         [%fetch fetch]
+        [%clear-cache (ot [%before (se %da)]~)]
     ==
   ::
   ++  commit

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -279,6 +279,18 @@
         [%author %s (scot %p author)]
         [%time (sect time)]
     ==
+  ::
+  ++  cache-size
+    |=  cache-size=(map @da [@ud @ud])
+    ^-  json
+    %-  pairs
+    %+  turn  ~(tap by cache-size)
+    |=  [day=@da number-cache-entries=@ud total-size=@ud]
+    :-  (@t +:(sect day))
+    %-  pairs
+    :+  [%number-cache-entries (numb number-cache-entries)]
+      [%total-size (numb total-size)]
+    ~
   --
 ::
 ++  dejs

--- a/lib/uqbuild.hoon
+++ b/lib/uqbuild.hoon
@@ -11,7 +11,7 @@
 ::    (2) surface whether the dependencies built
 ::        were result of a cache hit (is-hit=%.y)
 ::        or not
-::    (3) if =(%.y is-hit), we need to re-build here
+::    (3) if =(%.n is-hit), we need to re-build here
 ::        as well, since dependencies changed
 ::    (4) else, check if we have cached build
 ::    (5) if have cache: return cache hit
@@ -46,10 +46,17 @@
   =*  subject  subject.p.prelude-result
   =*  is-hit   is-hit.p.prelude-result
   ::  (3) & (4)
-  =/  cax  (~(get by cache.bus) file-hash)
+  =/  cax  (~(get by p.cache.bus) file-hash)
   ?:  &(is-hit ?=(^ cax))
     ::  (5)
-    [%&^u.cax^%.y bus(cycle (~(del in cycle.bus) p))]
+    :-  %&^u.cax^%.y
+    %=  bus
+        cycle  (~(del in cycle.bus) p)
+        q.cache
+      %.  [today.bus file-hash]
+      %~  del  ju
+      (~(put ju q.cache.bus) today.bus file-hash)
+    ==
   ::  (6)
   =/  =pile:clay  (pile:parse p (trip file-text))
   =/  build-result  (mule |.((slap subject hoon.pile)))
@@ -61,7 +68,8 @@
     ~&  bd+slap-fail+error-message
     [%|^p.build-result bus]
   =.  cache.bus
-    (~(put by cache.bus) file-hash p.build-result)
+    :-  (~(put by p.cache.bus) file-hash p.build-result)
+    (~(put ju q.cache.bus) today.bus file-hash)
   [%&^p.build-result^%.n bus(cycle (~(del in cycle.bus) p))]
 ::
 ++  build-file-internal
@@ -176,6 +184,12 @@
   ?:  (~(has by snap.bus) pux)
     pux
   $(paz t.paz)
+::
+++  da-to-today
+  |=  time=@da
+  ^-  @da
+  =/  date-form=date  (yore time)
+  (year date-form(t [d.t.date-form 0 0 0 ~]))
 ::
 ++  parse
   |%

--- a/lib/uqbuild.hoon
+++ b/lib/uqbuild.hoon
@@ -191,6 +191,17 @@
   =/  date-form=date  (yore time)
   (year date-form(t [d.t.date-form 0 0 0 ~]))
 ::
+++  compute-cache-size-by-day
+  ^-  (map @da [number-cache-entries=@ud total-size=@ud])
+  %-  ~(gas by *(map @da [@ud @ud]))
+  %+  turn  ~(tap by q.cache.bus)
+  |=  [day=@da entries=(set @ux)]
+  :-  day
+  %+  roll  ~(tap in entries)
+  |=  [entry=@ux [number-cache-entries=@ud total-size=@ud]]
+  :-  +(number-cache-entries)
+  (add total-size (met 3 (jam (~(got by p.cache.bus) entry))))
+::
 ++  parse
   |%
   ++  pile-imports

--- a/mar/linedb/cache-size.hoon
+++ b/mar/linedb/cache-size.hoon
@@ -1,0 +1,16 @@
+/+  linedb
+::
+|_  cache-size=(map @da [number-cache-entries=@ud total-size=@ud])
+++  grab
+  |%
+  ++  noun  ,(map @da [number-cache-entries=@ud total-size=@ud])
+  --
+::
+++  grow
+  |%
+  ++  noun  cache-size
+  ++  json  cache-size:enjs:linedb
+  --
+::
+++  grad  %noun
+--

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -67,6 +67,7 @@
           file=path
           =poke-src
       ==
+      [%clear-cache before=@da]
   ==
 +$  update
   $@  ~

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -38,9 +38,12 @@
   ==
 +$  build-state
   $:  =snap
-      cache=(map @ux vase)
+      cache=build-cache
       cycle=(set path)
+      today=@da
   ==
++$  build-cache
+  (pair (map @ux vase) (jug @da @ux))
 ::
 +$  action
   $%  ::  %linedb actions


### PR DESCRIPTION
**Problem**

#50

**Solution**

1. Track last time (specifically date) a cache entry was touched (created or used).
2. Add a scry that returns a map from date to number of entries and a rough estimate of total size of cache entries at that date.
3. Add a poke that clears all cache entries that haven't been touched starting from some given date.

**Notes**

None.