### PR TITLE
uqbuild: refactor to use `byob`

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -128,7 +128,7 @@
         :^  ~  ~  %linedb-cache-size
         !>  ^-  %+  map  @da
                 [number-cache-entries=@ud total-size=@ud]
-        ~(compute-cache-size-by-day ub ~ cache ~ *@da)
+        ~(compute-cache-size-by-day ub ~ cache ~ *@da ~)
       ::
           [%x ~]                                       ::  list all repos
         :^  ~  ~  %linedb-all-repos
@@ -313,7 +313,7 @@
       ?~  hash.act  head-snap:(ba-core [from repo branch ~]:act)
       (get-snap:(ba-core [from repo branch ~]:act) u.hash.act)
     =^  result=(each [@tas yoki:clay rang:clay] @t)  cache
-      (build-park snap repo.act)
+      (build-park snap [repo byob]:act)
     :_  state
     ?:  ?=(%| -.result)  ~
     [%pass / %arvo %c %park p.result]~
@@ -323,7 +323,7 @@
       ?~  hash.act  head-snap:(ba-core [from repo branch ~]:act)
       (get-snap:(ba-core [from repo branch ~]:act) u.hash.act)
     =^  result=(each [@tas yoki:clay rang:clay] @t)  cache
-      (build-park snap repo.act)
+      (build-park snap [repo byob]:act)
     :_  state
     ?~  poke-src.act  ~
     :_  ~
@@ -345,7 +345,7 @@
     =/  [built-file=(each vase tang) =build-state]
       %.  file.act
       %~  build-file  ub
-      :_  [cache ~ (da-to-today:ub now.bowl)]
+      :_  [cache ~ (da-to-today:ub now.bowl) byob.act]
       ?~  hash.act  head-snap:(ba-core [from repo branch ~]:act)
       (get-snap:(ba-core [from repo branch ~]:act) u.hash.act)
     :_  state(cache cache.build-state)
@@ -394,6 +394,7 @@
 ++  build-park
   |=  $:  =snap
           desk-name=@tas
+          =byob
       ==
   ^-  [(each [@tas yoki:clay rang:clay] @t) _cache]
   =/  bill=(list dude:gall)
@@ -409,7 +410,8 @@
     ?~  bill  [res cache]
     =/  [built-file=(each vase tang) =build-state]
       %.  /app/[i.bill]/hoon
-      ~(build-file ub snap cache ~ (da-to-today:ub now.bowl))
+      %~  build-file  ub
+      [snap cache ~ (da-to-today:ub now.bowl) byob]
     %=  $
       bill   t.bill
       res    [[i.bill built-file] res]

--- a/lib/uqbuild.hoon
+++ b/lib/uqbuild.hoon
@@ -5,6 +5,7 @@
   |=  =path
   (of-wain:format (~(got by snap.bus) path))
 ::
+::  TODO: rewrite this
 ::  +build-dependency
 ::    (1) parse the imports and recursively call
 ::        +build-dependency on them,
@@ -19,6 +20,7 @@
 ::
 ++  build-dependency
   |=  dep=(each [dir=path fil=path] path)
+  ~&  %bd^%bus^~(wyt by snap.bus)^~(wyt by p.cache.bus)^~(wyt by cycle.bus)^?=(~ byob.bus)
   ^-  [(each [=vase is-hit=?] tang) build-state]
   =/  p=path  ?:(?=(%| -.dep) p.dep fil.p.dep)
   ~|  error-building+p
@@ -31,20 +33,28 @@
   ?>  =(%hoon (rear p))
   =/  file-text=@t   (read-file p)
   =/  file-hash=@ux  (shax file-text)
+  =/  build-system=byob
+    ?^  byob.bus  byob.bus  `[!>(parse) !>(run-prelude)]
+  ?>  ?=(^ build-system)
   ::  (1) & (2)
-  =/  =pile-imports  (pile-imports:parse p (trip file-text))
-  =^    prelude-result=(each [subject=vase is-hit=?] tang)
+  =/  parsed-imports=vase
+    %+  slym  (slap parse.u.build-system (ream %imports))
+    [p (trip file-text)]
+  =/  build-subject-result-vase=vase
+    (slam build-subject.u.build-system parsed-imports)
+  =^    build-subject-result=(each (pair vase ?) tang)
       bus
-    (run-prelude pile-imports)
-  ?:  ?=(%| -.prelude-result)
+    !<  [(each [vase ?] tang) build-state]
+    build-subject-result-vase
+  ?:  ?=(%| -.build-subject-result)
     =*  error-message
       %-  of-wain:format
-      %+  turn  p.prelude-result
+      %+  turn  p.build-subject-result
       |=(=tank (crip ~(ram re tank)))
-    ~&  bd+prelude-fail+error-message
-    [%|^p.prelude-result bus]
-  =*  subject  subject.p.prelude-result
-  =*  is-hit   is-hit.p.prelude-result
+    ~&  bd+build-subject-fail+error-message
+    [%|^p.build-subject-result bus]
+  =*  subject  p.p.build-subject-result
+  =*  is-hit   q.p.build-subject-result
   ::  (3) & (4)
   =/  cax  (~(get by p.cache.bus) file-hash)
   ?:  &(is-hit ?=(^ cax))
@@ -58,8 +68,11 @@
       (~(put ju q.cache.bus) today.bus file-hash)
     ==
   ::  (6)
-  =/  =pile:clay  (pile:parse p (trip file-text))
-  =/  build-result  (mule |.((slap subject hoon.pile)))
+  =/  parsed-hoon-vase=vase
+    %+  slym  (slap parse.u.build-system (ream %hoon))
+    [p (trip file-text)]
+  =+  !<(parsed-hoon=hoon parsed-hoon-vase)
+  =/  build-result  (mule |.((slap subject parsed-hoon)))
   ?:  ?=(%| -.build-result)
     =*  error-message
       %-  of-wain:format
@@ -204,11 +217,11 @@
 ::
 ++  parse
   |%
-  ++  pile-imports
+  ++  imports
     |=  [pax=path tex=tape]
-    ^-  ^pile-imports
-    =/  [=hair res=(unit [pile=^pile-imports =nail])]
-      ((pile-imports-rule pax) [1 1] tex)
+    ^-  pile-imports
+    =/  [=hair res=(unit [pile=pile-imports =nail])]
+      ((imports-rule pax) [1 1] tex)
     ?^  res  pile.u.res
     %-  mean  %-  flop
     =/  lyn  p.hair
@@ -224,7 +237,7 @@
         leaf+(runt [(dec col) '-'] "^")
     ==
   ::
-  ++  pile-imports-rule
+  ++  imports-rule
     |=  pax=path
     %+  ifix
       :_  gay
@@ -251,10 +264,16 @@
       ==
     ==
   ::
-  ++  pile
+  ++  hoon
+    |=  [pax=path tex=tape]
+    ^-  ^hoon
+    hoon:(full-file pax tex)
+  ::
+  ++  full-file
     |=  [pax=path tex=tape]
     ^-  pile:clay
-    =/  [=hair res=(unit [=pile:clay =nail])]  ((pile-rule pax) [1 1] tex)
+    =/  [=hair res=(unit [=pile:clay =nail])]
+      ((full-file-rule pax) [1 1] tex)
     ?^  res  pile.u.res
     %-  mean  %-  flop
     =/  lyn  p.hair
@@ -270,7 +289,7 @@
         leaf+(runt [(dec col) '-'] "^")
     ==
   ::
-  ++  pile-rule
+  ++  full-file-rule
     |=  pax=path
     ::  TODO I believe we can delete a lot of this since we aren't parsing
     ::    certain ford runes

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -41,9 +41,11 @@
       cache=build-cache
       cycle=(set path)
       today=@da
+      =byob
   ==
-+$  build-cache
-  (pair (map @ux vase) (jug @da @ux))
++$  build-cache  (pair (map @ux vase) (jug @da @ux))
+::  $bring-your-own-build(system)
++$  byob  (unit [parse=vase build-subject=vase])
 ::
 +$  action
   $%  ::  %linedb actions
@@ -57,8 +59,8 @@
       [%fetch from=@p repo=@tas branch=@tas]
       ::  %uqbuild action
       ::
-      [%install from=@p repo=@tas branch=@tas hash=(unit hash)] :: put into clay
-      [%make-install-args from=@p repo=@tas branch=@tas hash=(unit hash) =poke-src]
+      [%install from=@p repo=@tas branch=@tas hash=(unit hash) =byob] :: put into clay
+      [%make-install-args from=@p repo=@tas branch=@tas hash=(unit hash) =poke-src =byob]
       $:  %build 
           from=@p
           repo=@tas
@@ -66,6 +68,7 @@
           hash=(unit hash)
           file=path
           =poke-src
+          =byob
       ==
       [%clear-cache before=@da]
   ==


### PR DESCRIPTION
**Problem**

#16 

**Solution**

Similar to #16: pass in optional `byob`; if not given, use default.

**Notes**

WIP

I am not sure this will work as is. Working for default as of ec2a9bb. I suspect state will not get passed properly when bringing own build system; we'll see in the next step, which will be to use %uqbuild to build a contract (i.e. refactor the contract compiler in %ziggurat to use %uqbuild).