### PR TITLE
linedb: add %clone

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -308,6 +308,10 @@
     =^  cards  subs  (surf:dab from.act dap.bowl [repo branch ~]:act)
     [cards state]
   ::
+      %clone
+    =.  pubs  (fork:dub [repo branch ~]:act [new-repo branch ~]:act)
+    `state
+  ::
       %install
     =/  =snap
       ?~  hash.act  head-snap:(ba-core [from repo branch ~]:act)

--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -308,7 +308,7 @@
     =^  cards  subs  (surf:dab from.act dap.bowl [repo branch ~]:act)
     [cards state]
   ::
-      %clone
+      %fork
     =.  pubs  (fork:dub [repo branch ~]:act [new-repo branch ~]:act)
     `state
   ::

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -359,6 +359,7 @@
         [%merge merge]
         [%branch branch]
         [%fetch fetch]
+        [%clone clone]
         [%clear-cache (ot [%before (se %da)]~)]
     ==
   ::
@@ -409,6 +410,14 @@
     :^    [%from (se %p)]
         [%repo (se %tas)]
       [%branch (se %tas)]
+    ~
+  ::
+  ++  clone
+    ^-  $-(json [@tas @tas @tas])
+    %-  ot
+    :^    [%repo (se %tas)]
+        [%branch (se %tas)]
+      [%new-repo (se %tas)]
     ~
   ::
   ++  snap

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -359,7 +359,7 @@
         [%merge merge]
         [%branch branch]
         [%fetch fetch]
-        [%clone clone]
+        [%fork fork]
         [%clear-cache (ot [%before (se %da)]~)]
     ==
   ::
@@ -412,7 +412,7 @@
       [%branch (se %tas)]
     ~
   ::
-  ++  clone
+  ++  fork
     ^-  $-(json [@tas @tas @tas])
     %-  ot
     :^    [%repo (se %tas)]

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -57,6 +57,7 @@
       [%reset repo=@tas branch=@tas =hash]
       [%branch from=@p repo=@tas branch=@tas name=@tas]
       [%fetch from=@p repo=@tas branch=@tas]
+      [%clone repo=@tas branch=@tas new-repo=@tas]
       ::  %uqbuild action
       ::
       [%install from=@p repo=@tas branch=@tas hash=(unit hash)] :: put into clay

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -57,7 +57,7 @@
       [%reset repo=@tas branch=@tas =hash]
       [%branch from=@p repo=@tas branch=@tas name=@tas]
       [%fetch from=@p repo=@tas branch=@tas]
-      [%clone repo=@tas branch=@tas new-repo=@tas]
+      [%fork repo=@tas branch=@tas new-repo=@tas]
       ::  %uqbuild action
       ::
       [%install from=@p repo=@tas branch=@tas hash=(unit hash)] :: put into clay


### PR DESCRIPTION
Add %clone to create a new repo copied from given local branch. So whereas %branch does

```
repo-host /repo-name/branch-name 
->
repo-host /repo-name/new-branch-name
```

%clone does

```
our /repo-name/branch-name
->
our /new-repo-name/branch-name
```

Open to alternative solutions here, but we definitely need the ability to copy an existing repo/branch to a new repo name.