### PR TITLE
uqbuild: allow multiple repos for %build: search in list order

### DIFF
--- a/app/linedb.hoon
+++ b/app/linedb.hoon
@@ -364,8 +364,10 @@
       %.  file.act
       %~  build-file  ub
       :_  [cache ~ (da-to-today:ub now.bowl)]
-      ?~  hash.act  head-snap:(ba-core [from repo branch ~]:act)
-      (get-snap:(ba-core [from repo branch ~]:act) u.hash.act)
+      %+  turn  repos.act
+      |=  [from=@p repo=@tas branch=@tas hash=(unit hash)]
+      ?~  hash  head-snap:(ba-core from repo branch ~)
+      (get-snap:(ba-core from repo branch ~) u.hash)
     :_  state(cache cache.build-state)
     ?~  poke-src.act  ~
     :_  ~
@@ -429,7 +431,7 @@
     ?~  bill  [res cache]
     =/  [built-file=(each vase tang) =build-state]
       %.  /app/[i.bill]/hoon
-      ~(build-file ub snap cache ~ (da-to-today:ub now.bowl))
+      ~(build-file ub [snap]~ cache ~ (da-to-today:ub now.bowl))
     %=  $
       bill   t.bill
       res    [[i.bill built-file] res]

--- a/lib/uqbuild.hoon
+++ b/lib/uqbuild.hoon
@@ -3,7 +3,11 @@
 |_  bus=build-state
 ++  read-file
   |=  =path
-  (of-wain:format (~(got by snap.bus) path))
+  %-  of-wain:format
+  |-
+  ?~  snaps.bus  !!
+  ?^  contents=(~(get by i.snaps.bus) path)  u.contents
+  $(snaps.bus t.snaps.bus)
 ::
 ::  +build-dependency
 ::    (1) parse the imports and recursively call
@@ -181,8 +185,12 @@
     ~&  "no files match /{(trip pre)}/{(trip pax)}/hoon"
     !!
   =/  pux=path  pre^(snoc i.paz %hoon)
-  ?:  (~(has by snap.bus) pux)
-    pux
+  =/  has=?
+    |-
+    ?~  snaps.bus                    %.n
+    ?:  (~(has by i.snaps.bus) pux)  %.y
+    $(snaps.bus t.snaps.bus)
+  ?:  has  pux
   $(paz t.paz)
 ::
 ++  da-to-today

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -37,7 +37,7 @@
       bar=(list [face=term =mark =path])
   ==
 +$  build-state
-  $:  =snap
+  $:  snaps=(list snap)
       cache=build-cache
       cycle=(set path)
       today=@da
@@ -70,10 +70,7 @@
           clay-info=(unit [yaki:clay rang:clay])
       ==
       $:  %build 
-          from=@p
-          repo=@tas
-          branch=@tas
-          hash=(unit hash)
+          repos=(list [from=@p repo=@tas branch=@tas hash=(unit hash)])
           file=path
           =poke-src
       ==


### PR DESCRIPTION
Change `build-state` to accept a list of `snap`s; %build to accept a list of repos. If don't find a file in a `snap`, proceed to looking in the next in list.

%ziggurat uses this for project repos, which may have deps for test threads that live in dev repos.